### PR TITLE
Add the -T/--top argument to set top level module manually

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: main branch autotests
 
 on:
   push:
-    branches: [main, 25-test-infrastructure]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/man-page/verilogtree.1
+++ b/man-page/verilogtree.1
@@ -51,6 +51,10 @@ List modules whose child modules shall be ignored when generating console
 output. Multiple modules can be listed one after the other.
 .PP
 .TP
+.B -T/--top
+List modules that shall be treated as top level modules.
+.PP
+.TP
 .B --lang
 Specify either of 'verilog' or 'vhdl' as the target language. Currently, 
 in verilogtree v0.1.x, only 'verilog' is supported.

--- a/man-page/verilogtree.1
+++ b/man-page/verilogtree.1
@@ -115,6 +115,19 @@ out the filenames. Consider a filelist named \fBsimple_filelist\fP with the foll
 The following command could then be used to generate the above verilogtree output:
 \fIverilogtree --no-inst-name --filelist simple_filelist\fP
 
+Additionally, the top level module can be manually specified rather than relying on the automatic 
+top-level detection in verilogtree by using the --top argument. For example, in the above hierarchy,
+verilogtree can be told to treat mod0 as the top-level module by running the following:
+\fIverilogtree --no-inst-name --filelist simple_filelist --top mod0\fP, which will give the following
+print out:
+
+    mod0 
+    ├── mod3 
+    │   └── mod4 
+    └── mod1 
+        └── mod2
+
+
 .SH AUTHOR
 Written by Liam Skirrow (skirrowliam@gmail.com)
 .br

--- a/src/deriveHierarchyTree.cc
+++ b/src/deriveHierarchyTree.cc
@@ -37,6 +37,19 @@ void Tree::setParentNodes(std::vector<Node> pNodes){
     this->parentNodes = pNodes;
 }
 
+// linear search through the parentNodes vector and check for existence of Node with name str
+bool Tree::getParentNodeExistence(std::string str){
+    bool moduleExists = false;
+    for(int i = 0; i < this->parentNodes.size(); i++){
+        // check if module name matches, therefore module exists, break and return True
+        if(this->parentNodes.at(i).getModuleName() == str){
+            moduleExists = true;
+            break;
+        }
+    }
+    return moduleExists;
+}
+
 Node * Tree::getParentNodeAtIndex(int index){
     Node *pNodePtr;
     pNodePtr = &this->parentNodes.at(index);
@@ -343,8 +356,14 @@ void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::ve
     if(topModules.size() > 0){
         Node *tmpNode;
         for(int i = 0; i < topModules.size(); i++){
-            tmpNode = hTreePtr->getMapElem(topModules.at(i));
-            hTreePtr->pushTreeRoot(*tmpNode);
+            // check if module exists in the design
+            if(!hTreePtr->getParentNodeExistence(topModules.at(i))){
+                std::cout << "*** Error: Specified top-level module: \"" << topModules.at(i) << "\" does not exist!" << std::endl;
+            }
+            else{
+                tmpNode = hTreePtr->getMapElem(topModules.at(i));
+                hTreePtr->pushTreeRoot(*tmpNode);
+            }
         }
     }
     else{

--- a/src/deriveHierarchyTree.cc
+++ b/src/deriveHierarchyTree.cc
@@ -358,7 +358,7 @@ void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::ve
         for(int i = 0; i < topModules.size(); i++){
             // check if module exists in the design
             if(!hTreePtr->getParentNodeExistence(topModules.at(i))){
-                std::cout << "*** Error: Specified top-level module: \"" << topModules.at(i) << "\" does not exist!" << std::endl;
+                std::cout << "*** Warning: Specified top-level module: \"" << topModules.at(i) << "\" does not exist!" << std::endl;
             }
             else{
                 tmpNode = hTreePtr->getMapElem(topModules.at(i));

--- a/src/deriveHierarchyTree.cc
+++ b/src/deriveHierarchyTree.cc
@@ -289,7 +289,7 @@ void constructTreeRecursively(Node *pNodePtr, Tree *hTreePtr, bool debug, bool s
 }
 
 // main algorithm for elaborating the tree of parent nodes
-void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::vector<std::string> noIncModules, int maxHierarchyLevel){
+void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::vector<std::string> noIncModules, std::vector<std::string> topModules, int maxHierarchyLevel){
     // algorithm:
     // - the hash table allows for a lookup of a module, given the module name. Returns the ParentNode object
     // - iterate over the hTree parent nodes and assign child nodes as instantiated using the isInstantiated bool
@@ -336,13 +336,26 @@ void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::ve
         }
     }
 
-    // find the top level modules and push to Tree's tree root vector
-    for(int i = 0; i < parentNodeSize; i++){
-        pNodePtr = hTreePtr->getParentNodeAtIndex(i);
-        testInstantiated = hTreePtr->getMapElem(pNodePtr->getModuleName())->getIsInstantiated();
-        if(!testInstantiated){
-            // now add the top level modules to the Tree's root nodes vector
-            hTreePtr->pushTreeRoot(*pNodePtr);
+    // TODO: issue #45, print out at the bottom "Using <modules> as top level modules"
+
+    // before assigning the top level modules, check if the user has specified the top modules,
+    // otherwise, infer them automatically by figuring out which modules are *not* instantiated
+    if(topModules.size() > 0){
+        Node *tmpNode;
+        for(int i = 0; i < topModules.size(); i++){
+            tmpNode = hTreePtr->getMapElem(topModules.at(i));
+            hTreePtr->pushTreeRoot(*tmpNode);
+        }
+    }
+    else{
+        // find the top level modules and push to Tree's tree root vector
+        for(int i = 0; i < parentNodeSize; i++){
+            pNodePtr = hTreePtr->getParentNodeAtIndex(i);
+            testInstantiated = hTreePtr->getMapElem(pNodePtr->getModuleName())->getIsInstantiated();
+            if(!testInstantiated){
+                // now add the top level modules to the Tree's root nodes vector
+                hTreePtr->pushTreeRoot(*pNodePtr);
+            }
         }
     }
     // assemble the final tree, starting at the tree roots
@@ -387,7 +400,7 @@ void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::ve
 }
 
 // top level function, dispatch the rtl parsing and tree construction functions, return the Tree to main
-Tree deriveHierarchyTree(Tree *hTreePtr, std::vector<std::string> rtlFiles, std::regex parentNodeRegexStr, std::regex childNodeRegexStr, bool debug, bool superDebug, std::vector<std::string> noIncModules, int maxHierarchyLevel){
+Tree deriveHierarchyTree(Tree *hTreePtr, std::vector<std::string> rtlFiles, std::regex parentNodeRegexStr, std::regex childNodeRegexStr, bool debug, bool superDebug, std::vector<std::string> noIncModules, int maxHierarchyLevel, std::vector<std::string> topModules){
 
     Tree hTree;
     // Tree *hTreePtr;
@@ -430,7 +443,24 @@ Tree deriveHierarchyTree(Tree *hTreePtr, std::vector<std::string> rtlFiles, std:
     hTreePtr->setMap(*pNodeMapPtr);
 
     // now (recursively?) replace all child nodes with parent nodes to construct the tree
-    elaborateHierarchyTree(hTreePtr, debug, superDebug, noIncModules, maxHierarchyLevel);
+    elaborateHierarchyTree(hTreePtr, debug, superDebug, noIncModules, topModules, maxHierarchyLevel);
+
+    // replace the tree with the manually specified top-level modules, if necessary
+    if(topModules.size() > 0){
+        // - loop over the specified top modules
+        // - perform a lookup for each one, and if it exists, override the existing 'treeRoots' std::vector<Node>
+
+        // ALTERNATIVE METHOD:
+        // - perform a lookup for each top-level module passed in by the user
+        // - override each Node's isInstantiated flag to false, this should cause it to be treated as a tree root
+        //   by one of my functions... This is the easiest approach and should hopefully work ok!
+        
+        // - line 335 above is where the setIsInstantiated setter method gets called, just include a conditional
+        //   up there to check if the Node is a module that the user wants to treat as a top module, and if so 
+        //   then don't call the setter method...
+        // - after that, delete *this* conditional and these comments
+    }
+
 
     return *hTreePtr;
 

--- a/src/include/deriveHierarchyTree.h
+++ b/src/include/deriveHierarchyTree.h
@@ -60,8 +60,8 @@ class Tree{
         int getTreeRootSize();
 };
 
-Tree deriveHierarchyTree(Tree *hierarchyTreePtr, std::vector<std::string> rtlFiles, std::regex parentNodeRegexStr, std::regex childNodeRegexStr, bool debug, bool superDebug, std::vector<std::string> noIncModules, int maxHierarchyLevel);
+Tree deriveHierarchyTree(Tree *hierarchyTreePtr, std::vector<std::string> rtlFiles, std::regex parentNodeRegexStr, std::regex childNodeRegexStr, bool debug, bool superDebug, std::vector<std::string> noIncModules, int maxHierarchyLevel, std::vector<std::string> topModules);
 void parseRtl(std::vector<std::string> rtlFiles, std::vector<Node> *parentNodeVecPtr, std::regex parentNodeRegexStr, std::regex childNodeRegexStr, std::map<std::string, Node> *pNodeMapPtr, bool debug);
-void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::vector<std::string> noIncModules, int maxHierarchyLevel);
+void elaborateHierarchyTree(Tree *hTreePtr, bool debug, bool superDebug, std::vector<std::string> noIncModules, std::vector<std::string> topModules, int maxHierarchyLevel);
 void tokenizeString(std::string str, std::string *tokenisedStringPtr);
 void constructTreeRecursively(Node *pNodePtr, Tree *hTreePtr, bool debug, bool superDebug, std::vector<std::string> noIncModules, int level, int maxHierarchyLevel);

--- a/src/include/deriveHierarchyTree.h
+++ b/src/include/deriveHierarchyTree.h
@@ -49,6 +49,7 @@ class Tree{
 
     public:
         void setParentNodes(std::vector<Node> pNodes);
+        bool getParentNodeExistence(std::string str);
         Node * getParentNodeAtIndex(int index);
         int getParentNodesSize();
         void setMap(std::map<std::string, Node> pNodeMap);

--- a/src/include/parseUserArgs.h
+++ b/src/include/parseUserArgs.h
@@ -12,6 +12,7 @@ struct Arguments{
     std::vector<std::string> rtlFiles;
     std::vector<std::string> noIncModules;
     std::string codeVersion  = "v0.1.0-dev";
+    std::vector<std::string> topModules;
     std::string lang         = "verilog";
     std::string level        = "-1";
     std::string algorithm    = "recursive";
@@ -21,7 +22,7 @@ struct Arguments{
     int maxHierarchyLevel    = 100;
 };
 
-struct Arguments parseUserArgs(int argc, char **argv, std::array<std::string,18> argList);
+struct Arguments parseUserArgs(int argc, char **argv, std::array<std::string,20> argList);
 void errorAndExit(std::string errorMsg);
 int getNextArgs(int argc, char **argv, int i, std::string argName, std::string errMsg, std::vector<std::string> *argumentVecPtr);
 void printHelp();

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,6 +23,12 @@ void dumpArgsStruct(struct Arguments args){
     }
     std::cout << std::endl;
 
+    std::cout << "Top level modules: " << args.topModules.size() << std::endl;
+    for(int i = 0; i < args.topModules.size(); i++){
+        std::cout << "    " << args.topModules.at(i) << std::endl;
+    }
+    std::cout << std::endl;
+
     std::cout << "level arg: " << std::endl;
     std::cout << "    " << args.level;
     std::cout << std::endl;
@@ -174,7 +180,7 @@ int main(int argc, char **argv){
 
     // TODO: figure out what to do with --iterative and --recursive? Probably not going to implement these afterall
     // accepted list of arguments, must remember to update number in parentheses!!!
-    std::array<std::string,18> argListFlags = 
+    std::array<std::string,20> argListFlags = 
                               {"-h",             // display usage and flags information
                                "--help",
                                "-f",             // file paths
@@ -187,6 +193,8 @@ int main(int argc, char **argv){
                                "--max-hierarchy",
                                "-n",             // don't print out this/these module names
                                "--ignore-modules",
+                               "-T",             // manually specify top-level module(s)
+                               "--top",
                                "--lang",         // one of either [verilog ^ vhdl]
                                "--debug",        // more verbose output, print out internal variables
                                "--super-debug",  // print out even more debug output

--- a/src/main.cc
+++ b/src/main.cc
@@ -166,6 +166,15 @@ void printTree(Tree hierarchyTree, struct Arguments args){
         }
         std::cout << std::endl;
     }
+
+    // print a summary of the top level modules as a reminder
+    if(args.topModules.size() > 0){
+        std::cout << "User specified top-level modules: ";
+        for(int j = 0; j < args.topModules.size(); j++){
+            std::cout << args.topModules.at(j) << " ";
+        }
+        std::cout << std::endl;
+    }
 }
 
 int main(int argc, char **argv){

--- a/src/main.cc
+++ b/src/main.cc
@@ -230,7 +230,7 @@ int main(int argc, char **argv){
 
     // now parse the Verilog/VHDL, searching for the key phrases and generate the logical hierarchy
     // this is the main algorithm to configure the tree
-    hierarchyTree = deriveHierarchyTree(hierarchyTreePtr, args.rtlFiles, parentNodeRegexStr, childNodeRegexStr, args.debug, args.superDebug, args.noIncModules, args.maxHierarchyLevel);
+    hierarchyTree = deriveHierarchyTree(hierarchyTreePtr, args.rtlFiles, parentNodeRegexStr, childNodeRegexStr, args.debug, args.superDebug, args.noIncModules, args.maxHierarchyLevel, args.topModules);
 
     // display the tree structure of the RTL
     printTree(hierarchyTree, args);

--- a/src/parseUserArgs.cc
+++ b/src/parseUserArgs.cc
@@ -34,7 +34,7 @@ int getNextArgs(int argc, char **argv, int i, std::string argName, std::string e
     return i;
 }
 
-struct Arguments parseUserArgs(int argc, char **argv, std::array<std::string,18> argList){
+struct Arguments parseUserArgs(int argc, char **argv, std::array<std::string,20> argList){
 
     int isEqual;
     bool includedVerilog = false;
@@ -141,6 +141,12 @@ struct Arguments parseUserArgs(int argc, char **argv, std::array<std::string,18>
             // now give the args structure the relevant filenames
             args.noIncModules = *argumentVecPtr;
         } 
+        else if(argv[i] == (std::string)"-T" || argv[i] == (std::string)"--top"){
+            // check the next N strings of argv to get the top level module(s), increment i accordingly
+            i = getNextArgs(argc, argv, i, argv[i], (std::string)"names of top-level modules to include", argumentVecPtr);
+            // now give the args structure the relevant filenames
+            args.topModules = *argumentVecPtr;
+        } 
         else if(argv[i] == (std::string)"--lang"){
             // check the next string of argv to get the language, increment i accordingly
             i = getNextArgs(argc, argv, i, argv[i], (std::string)"one of [verilog | vhdl]", argumentVecPtr);
@@ -209,6 +215,8 @@ void printHelp(){
     -n / --ignore-modules      List modules whose child modules shall be ignored   \n\
                                when generating console output. Multiple modules    \n\
                                can be listed one after the other.                  \n\
+    -T / --top                 List modules that shall be treated as top level     \n\
+                               modules.                                            \n\
     --lang                     Specify either of 'verilog' or 'vhdl' as the target \n\
                                language. Currently, in verilogtree v0.1.x, only    \n\
                                'verilog' is supported.                             \n\


### PR DESCRIPTION
Opening PR to enable GH action builds + test runner

Manually specify a top-level module rather than relying on verilogtree to automatically infer it